### PR TITLE
Link Typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 # intro_to_scrapy
 Intro to Scrapy presentation for Python Frederick's April 10, 2024 Meetup
+
+
+Helpful resources:
+  Scrapy Docs: https://docs.scrapy.org/en/latest/index.html
+  John Watson Rooney's YouTube channel: https://www.youtube.com/@JohnWatsonRooney
+  Zyte Webscraping Sandbox: http://toscrape.com/

--- a/README.md
+++ b/README.md
@@ -3,7 +3,11 @@ Intro to Scrapy presentation for Python Frederick's April 10, 2024 Meetup
 
 
 Helpful resources:
-  Scrapy Docs: https://docs.scrapy.org/en/latest/index.html \n
-  John Watson Rooney's YouTube channel: https://www.youtube.com/@JohnWatsonRooney \m
-  Zyte Webscraping Sandbox: http://toscrape.com/\ \n
-  scrapy-playwright: https://github.com/scrapy-plugins/scrapy-playwright \n
+  <br>
+  Scrapy Docs: https://docs.scrapy.org/en/latest/index.html
+  <br>
+  John Watson Rooney's YouTube channel: https://www.youtube.com/@JohnWatsonRooney
+  <br>
+  Zyte Webscraping Sandbox: http://toscrape.com/\
+  <br>
+  scrapy-playwright: https://github.com/scrapy-plugins/scrapy-playwright

--- a/README.md
+++ b/README.md
@@ -10,4 +10,4 @@ Helpful resources:
   <br>
   &emsp;Zyte Webscraping Sandbox: http://toscrape.com/\
   <br>
-  &emsp;scrapy-playwright: https://github.com/scrapy-plugins/scrapy-playwright
+  &emsp;scrapy-playwright Docs: https://github.com/scrapy-plugins/scrapy-playwright

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ Intro to Scrapy presentation for Python Frederick's April 10, 2024 Meetup
 
 
 Helpful resources:
-  Scrapy Docs: https://docs.scrapy.org/en/latest/index.html
-  John Watson Rooney's YouTube channel: https://www.youtube.com/@JohnWatsonRooney
-  Zyte Webscraping Sandbox: http://toscrape.com/
+  Scrapy Docs: https://docs.scrapy.org/en/latest/index.html \n
+  John Watson Rooney's YouTube channel: https://www.youtube.com/@JohnWatsonRooney \m
+  Zyte Webscraping Sandbox: http://toscrape.com/\ \n
+  scrapy-playwright: https://github.com/scrapy-plugins/scrapy-playwright \n

--- a/README.md
+++ b/README.md
@@ -8,6 +8,6 @@ Helpful resources:
   <br>
   &emsp;John Watson Rooney's YouTube channel: https://www.youtube.com/@JohnWatsonRooney
   <br>
-  &emsp;Zyte Webscraping Sandbox: http://toscrape.com/\
+  &emsp;Zyte Webscraping Sandbox: http://toscrape.com/
   <br>
   &emsp;scrapy-playwright Docs: https://github.com/scrapy-plugins/scrapy-playwright

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ Intro to Scrapy presentation for Python Frederick's April 10, 2024 Meetup
 
 Helpful resources:
   <br>
-  Scrapy Docs: https://docs.scrapy.org/en/latest/index.html
+  &emsp;Scrapy Docs: https://docs.scrapy.org/en/latest/index.html
   <br>
-  John Watson Rooney's YouTube channel: https://www.youtube.com/@JohnWatsonRooney
+  &emsp;John Watson Rooney's YouTube channel: https://www.youtube.com/@JohnWatsonRooney
   <br>
-  Zyte Webscraping Sandbox: http://toscrape.com/\
+  &emsp;Zyte Webscraping Sandbox: http://toscrape.com/\
   <br>
-  scrapy-playwright: https://github.com/scrapy-plugins/scrapy-playwright
+  &emsp;scrapy-playwright: https://github.com/scrapy-plugins/scrapy-playwright

--- a/commands.txt
+++ b/commands.txt
@@ -3,7 +3,7 @@ source .venv/bin/activate
 pip install scrapy
 scrapy startproject pens
 cd pens
-scrapy genspider -t crawl pens gouletpens.com
+scrapy genspider -t crawl penspider gouletpens.com
 
                             SHELL COMMANDS
 scrapy shell <page to interact with>


### PR DESCRIPTION
Extra `\` at the end of the toscrape.com link